### PR TITLE
:bug: 현재 위치 불러오기 안되는 현상 수정

### DIFF
--- a/PlaceStory/Platform/Sources/RepositoryImps/LocationServiceRepositoryImp.swift
+++ b/PlaceStory/Platform/Sources/RepositoryImps/LocationServiceRepositoryImp.swift
@@ -33,7 +33,6 @@ public final class LocationServiceRepositoryImp: NSObject {
             
         case .authorizedAlways, .authorizedWhenInUse: // 앱을 사용중일 때, 위치 서비스를 이용할 수 있는 상태
             authorizationStatusSubject.send(true)
-            locationManager.startUpdatingLocation()
             
         @unknown default:
             authorizationStatusSubject.send(false)
@@ -52,6 +51,7 @@ extension LocationServiceRepositoryImp: LocationServiceRepository {
     }
     
     public func publishCurrentLocation() -> AnyPublisher<CLLocation, Error> {
+        locationManager.startUpdatingLocation()
         return updateLocationSubject.eraseToAnyPublisher()
     }
     


### PR DESCRIPTION
- LocationServiceRepositoryImp에서 startUpdatingLocation 메소드를 publishCurrentLocation 메소드 안에서 호출하게 변경하여 현재 위치 불러오기 현상 수정

[AS-IS]

https://github.com/f-lab-edu/PlaceStory/assets/60861313/aa55e483-a45a-441f-ac4a-15cdf5d8561c



[TO-BE]

https://github.com/f-lab-edu/PlaceStory/assets/60861313/49fa2627-edd3-4b39-92de-c761a2a4b915

