### PR TITLE
장소 검색 시 장소 선택할 때 앱 종료되는 현상

### DIFF
--- a/PlaceStory/MyLocation/Sources/PlaceSearcher/PlaceSearcherInteractor.swift
+++ b/PlaceStory/MyLocation/Sources/PlaceSearcher/PlaceSearcherInteractor.swift
@@ -68,7 +68,6 @@ final class PlaceSearcherInteractor: PresentableInteractor<PlaceSearcherPresenta
     
     func didChangeSearchText(_ text: String) {
         dependency.mapServiceUseCase.updateSearchText(text)
-            .filter { $0.count > 0 }
             .sink(receiveValue: { [weak self] placeSearchResults in
                 guard let self else { return }
                 


### PR DESCRIPTION
- 잘못 입력하면 검색된 배열에는 빈 배열이지만, 화면에 보여지는 리스트에는 기존에 검색되 배열이 남아있어서 선택을 할 수 있게됨 현재 검색된 배열과 화면에 보여지는 배열이 일치하지 않아 화면에 보여지는 배열의 요소를 선택하면 실제 검색된 배열에는 해당 index가 없어서 crash가 발생
- PlaceSearcherInteractor 파일에서 .filter 부분 삭제하여 해당 에러 현상 수정 완료

[AS-IS]
<img width="30%" src="https://github.com/f-lab-edu/PlaceStory/assets/60861313/e734e526-e0a0-424a-ae17-48930eae60a7"/>

[TO-BE]
<img width="30%" src="https://github.com/f-lab-edu/PlaceStory/assets/60861313/c823b415-f003-443c-8e29-2add8a0415b0"/>