### PR TITLE
Apple login refactor firebaseAuth

### DIFF
--- a/PlaceStory/AppRoot/Sources/AppRoot/AppRootRouter.swift
+++ b/PlaceStory/AppRoot/Sources/AppRoot/AppRootRouter.swift
@@ -61,10 +61,10 @@ final class AppRootRouter: LaunchRouter<AppRootInteractable, AppRootViewControll
         loggedOutRouter = nil
     }
     
-    func attachLoggedIn() {
+    func attachLoggedIn(with userID: String) {
         guard loggedInRouter == nil else { return }
         
-        let router = loggedInBuilder.build(withListener: interactor)
+        let router = loggedInBuilder.build(withListener: interactor, userID: userID)
         loggedInRouter = router
         attachChild(router)
         

--- a/PlaceStory/Domain/Sources/Repositories/AppleAuthenticationServiceRepository.swift
+++ b/PlaceStory/Domain/Sources/Repositories/AppleAuthenticationServiceRepository.swift
@@ -10,8 +10,8 @@ import Entities
 import Foundation
 
 public protocol AppleAuthenticationServiceRepository {
-    func signIn() -> AnyPublisher<AppleUser, Error>
+    func signIn() -> AnyPublisher<Bool, Error>
     func decodeWith(idToken: String) -> [String: Any]
     func fetchAppleSignInStatus() -> Future<Bool, Error>
-    func fetchUserInfo() -> AppleUser?
+    func fetchUserID() -> String?
 }

--- a/PlaceStory/Domain/Sources/UseCase/AppleAuthenticationServiceUseCase.swift
+++ b/PlaceStory/Domain/Sources/UseCase/AppleAuthenticationServiceUseCase.swift
@@ -11,9 +11,9 @@ import Foundation
 import Repositories
 
 public protocol AppleAuthenticationServiceUseCase {
-    func signInWithApple() -> AnyPublisher<AppleUser, Error>
+    func signInWithApple() -> AnyPublisher<Bool, Error>
     func checkPreviousSignInWithApple() -> Future<Bool, Error>
-    func fetchUserInfo() -> AppleUser?
+    func fetchUserID() -> String?
 }
 
 public final class AppleAuthenticationServiceUseCaseImp: AppleAuthenticationServiceUseCase {
@@ -26,7 +26,7 @@ public final class AppleAuthenticationServiceUseCaseImp: AppleAuthenticationServ
         self.appleAuthenticationServiceRepository = appleAuthenticationServiceRepository
     }
     
-    public func signInWithApple() -> AnyPublisher<AppleUser, Error> {
+    public func signInWithApple() -> AnyPublisher<Bool, Error> {
         appleAuthenticationServiceRepository.signIn()
     }
     
@@ -34,7 +34,7 @@ public final class AppleAuthenticationServiceUseCaseImp: AppleAuthenticationServ
         appleAuthenticationServiceRepository.fetchAppleSignInStatus()
     }
     
-    public func fetchUserInfo() -> AppleUser? {
-        return appleAuthenticationServiceRepository.fetchUserInfo()
+    public func fetchUserID() -> String? {
+        return appleAuthenticationServiceRepository.fetchUserID()
     }
 }

--- a/PlaceStory/LoggedIn/Sources/LoggedIn/LoggedInBuilder.swift
+++ b/PlaceStory/LoggedIn/Sources/LoggedIn/LoggedInBuilder.swift
@@ -14,12 +14,23 @@ public protocol LoggedInDependency: Dependency {
     var placeListBuilder: PlaceListBuildable { get }
 }
 
-final class LoggedInComponent: Component<LoggedInDependency> {}
+final class LoggedInComponent: Component<LoggedInDependency>, LoggedInInteractorDependency {
+    let userID: String
+    
+    init(
+        dependency: LoggedInDependency,
+        userID: String
+    ) {
+        self.userID = userID
+        
+        super.init(dependency: dependency)
+    }
+}
 
 // MARK: - Builder
 
 public protocol LoggedInBuildable: Buildable {
-    func build(withListener listener: LoggedInListener) -> LoggedInRouting
+    func build(withListener listener: LoggedInListener, userID: String) -> LoggedInRouting
 }
 
 public final class LoggedInBuilder: Builder<LoggedInDependency>, LoggedInBuildable {
@@ -28,10 +39,16 @@ public final class LoggedInBuilder: Builder<LoggedInDependency>, LoggedInBuildab
         super.init(dependency: dependency)
     }
     
-    public func build(withListener listener: LoggedInListener) -> LoggedInRouting {
-        let component = LoggedInComponent(dependency: dependency)
+    public func build(withListener listener: LoggedInListener, userID: String) -> LoggedInRouting {
+        let component = LoggedInComponent(
+            dependency: dependency,
+            userID: userID
+        )
         let viewController = LoggedInViewController()
-        let interactor = LoggedInInteractor(presenter: viewController)
+        let interactor = LoggedInInteractor(
+            presenter: viewController,
+            dependency: component
+        )
         interactor.listener = listener
         
         return LoggedInRouter(

--- a/PlaceStory/LoggedIn/Sources/LoggedIn/LoggedInInteractor.swift
+++ b/PlaceStory/LoggedIn/Sources/LoggedIn/LoggedInInteractor.swift
@@ -20,14 +20,23 @@ public protocol LoggedInListener: AnyObject {
     // TODO: Declare methods the interactor can invoke to communicate with other RIBs.
 }
 
+protocol LoggedInInteractorDependency {
+    var userID: String { get }
+}
+
 final class LoggedInInteractor: PresentableInteractor<LoggedInPresentable>, LoggedInInteractable, LoggedInPresentableListener {
 
+    private let dependency: LoggedInInteractorDependency
+    
     weak var router: LoggedInRouting?
     weak var listener: LoggedInListener?
-
-    // TODO: Add additional dependencies to constructor. Do not perform any logic
-    // in constructor.
-    override init(presenter: LoggedInPresentable) {
+    
+    init(
+        presenter: LoggedInPresentable,
+        dependency: LoggedInInteractorDependency
+    ) {
+        self.dependency = dependency
+        
         super.init(presenter: presenter)
         presenter.listener = self
     }

--- a/PlaceStory/PlaceStory/App/AppComponent.swift
+++ b/PlaceStory/PlaceStory/App/AppComponent.swift
@@ -38,7 +38,7 @@ final class AppComponent: Component<EmptyDependency>, AppRootDependency, LoggedO
     init() {
         let realmDatabaseImp = RealmDatabaseImp()
         let keychainService = KeychainServiceImp()
-        let appleAuthenticationServiceRepositoryImp = AppleAuthenticationServiceRepositoryImp(database: realmDatabaseImp, keychain: keychainService)
+        let appleAuthenticationServiceRepositoryImp = AppleAuthenticationServiceRepositoryImp()
         let appleAuthenticationServiceUseCaseImp = AppleAuthenticationServiceUseCaseImp(appleAuthenticationServiceRepository: appleAuthenticationServiceRepositoryImp)
         self.appleAuthenticationServiceUseCase = appleAuthenticationServiceUseCaseImp
         

--- a/PlaceStory/Platform/Sources/SecurityServices/KeychainService.swift
+++ b/PlaceStory/Platform/Sources/SecurityServices/KeychainService.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Security
 
-protocol KeychainService {
+public protocol KeychainService {
     func create(_ account: String, _ value: String) -> (isSucceed: Bool, resultMessage: String)
     func read(_ account: String) -> (readValue: String?, resultMessage: String)
     func update(_ account: String, _ value: String) -> (isSucceed: Bool, resultMessage: String)


### PR DESCRIPTION
[AS-IS]
- realm과 keychain을 사용하여 애플로그인 진행. userIdentifier를 keychain에 저장하고, 다음에 로그인 시 keychain에 저장된 userIdentifier를 이용하여 로그인 진행.
- Realm에서 사용하는 UserInfo 모델과, 도메인 모델인 AppleUser를 사용

[TO-BE]
- realm과 keychain을 제거하고, FirebaseAuth를 사용하여 애플로그인 진행. Bool 타입으로 로그인 성공여부 판단. 다음에 로그인시 user의 uid가 nil이 아니면 로그인 진행.
- UserInfo, AppleUser를 제거하고, uid를 LoggedIn Riblet에 전달